### PR TITLE
fix(plugin): correct provider url

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,10 @@ import (
 	"github.com/netactuate/terraform-provider-netactuate/netactuate"
 )
 
+const (
+	ProviderAddr = "registry.terraform.io/netactuate/netactuate"
+)
+
 func main() {
 	var debugMode bool
 
@@ -23,7 +27,7 @@ func main() {
 	}
 
 	if debugMode {
-		err := plugin.Debug(context.Background(), "github.com/netactuate/netactuate", opts)
+		err := plugin.Debug(context.Background(), ProviderAddr, opts)
 		if err != nil {
 			log.Fatal(err.Error())
 		}


### PR DESCRIPTION
per [plugin.ServeOpts] the `ProviderAddr` field is the provider registry URL, not the repository URL.


```golang
// ProviderAddr is the address of the provider under test or debugging,
// such as registry.terraform.io/hashicorp/random.
```
<https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.38.1/plugin/serve.go#L86-L87>

[plugin.Debug()](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/plugin#Debug) is deprecated, but the argument to the function is the same as the field to [plugin.ServeOpts]

[plugin.ServeOpts]: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/plugin#ServeOpts