### PR TITLE
fix(datasource): use HasError instead of nil check

### DIFF
--- a/netactuate/data_source_server.go
+++ b/netactuate/data_source_server.go
@@ -177,7 +177,7 @@ func dataSourceServerRead(ctx context.Context, d *schema.ResourceData, m interfa
 		setValue("bgp_peers", []map[string]interface{}{bgpPeers}, d, &diags)
 	}
 
-	if diags == nil {
+	if !diags.HasError() {
 		d.SetId(strconv.Itoa(server.ID))
 	}
 

--- a/netactuate/data_source_sshkey.go
+++ b/netactuate/data_source_sshkey.go
@@ -47,7 +47,7 @@ func dataSourceSshKeyRead(ctx context.Context, d *schema.ResourceData, m interfa
 	setValue("key", sshKey.Key, d, &diags)
 	setValue("fingerprint", sshKey.Fingerprint, d, &diags)
 
-	if diags == nil {
+	if !diags.HasError() {
 		d.SetId(strconv.Itoa(sshKey.ID))
 	}
 


### PR DESCRIPTION
two problems with the nil checks here.

1. if slice is empty, but not `nil`. these checks could be false and the ID was never set.
2. a non-nil and non-empty Diags is not guaranteed to be a failure, it could contain non-error informative diagnostics

```golang
	// Data resources that are designed to return state for a singular
	// infrastructure component should conventionally return an error if that
	// infrastructure does not exist and omit any calls to the
	// SetId method.
```

gate setting the id instead on the existence of no error diagnostics