### PR TITLE
fix(server): avoid nil check for diagnostics

### DIFF
--- a/netactuate/resource_server.go
+++ b/netactuate/resource_server.go
@@ -177,7 +177,7 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	c := m.(*gona.Client)
 
 	locationId, imageId, diags := getParams(d, c)
-	if diags != nil {
+	if diags.HasError() {
 		return diags
 	}
 	diags = diag.Diagnostics{}
@@ -325,11 +325,7 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 			oldLoc := oldLoc_r.(string)
 			setValue("location_id", 0, d, &diag.Diagnostics{})
 			if oldLoc != "" {
-				var diags diag.Diagnostics
 				unlinkRequired = true
-				if len(diags) > 0 {
-					return diags
-				}
 				if unlinkRequired {
 					err = c.UnlinkServer(id)
 					if err != nil {
@@ -356,7 +352,7 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 
 		// Get correct build params
 		locationId, imageId, diags := getParams(d, c)
-		if diags != nil {
+		if diags.HasError() {
 			return diags
 		}
 		req := &gona.BuildServerRequest{


### PR DESCRIPTION
diags might not be nil but instead merely empty as it is a slice. the check should be minimally `len(diags) > 0` not `nil`.
even if it is not empty, it may only contain non-error diagnostics.

```golang
// This helper aims to mimic the go error practices of if err != nil. After any
// operation that returns Diagnostics, check that it HasError and bubble up the
// stack.
```

unexported helpers within may hold the `nil` invariant, but terraform plugin helpers etc. may not.